### PR TITLE
Add random test for strformt::fmt()

### DIFF
--- a/Backend/sub_crates/str_util/src/tests/strformat.rs
+++ b/Backend/sub_crates/str_util/src/tests/strformat.rs
@@ -5,7 +5,7 @@ use crate::strformat;
 proptest! {
   /// This test is supplied with three random inputs:
   ///
-  /// 1. Size of the generated arguments, in interval `[0,32)`
+  /// 1. Size of the generated arguments, in interval `[0,32]`
   /// 2. Permutations of strings for generated arguments, `size = 32`
   /// 3. Strings to pick from, `size = 32`
   ///

--- a/Backend/sub_crates/str_util/src/tests/strformat.rs
+++ b/Backend/sub_crates/str_util/src/tests/strformat.rs
@@ -3,11 +3,27 @@ use self::proptest::prelude::*;
 use crate::strformat;
 
 proptest! {
+  /// This test is supplied with three random inputs:
+  ///
+  /// 1. Size of the generated arguments, in interval `[0,32)`
+  /// 2. Permutations of strings for generated arguments, `size = 32`
+  /// 3. Strings to pick from, `size = 32`
+  ///
+  /// The idea is to generate a format string with random indices, e.g. `"{2} {4} {0} {0}"`. The function `strformat::fmt()` then inserts the corresponding values from `strings`. Consider a `strings` array of `["A", "B", "C", "D", "E", "F"]` we get a format string of `"C E A A"`.
   #[test]
   fn test_arguments(size in 0usize..33usize, permutations in prop::array::uniform32(0usize..32usize), strings in prop::array::uniform32("\\PC*")) {
-    let format = (0..size).map(|i| format!("{{{}}}", permutations[i])).collect::<Vec<_>>().join(" ");
-    let arguments = strings.iter().map(|item| &item[..]).collect::<Vec<_>>();
-    let expected = (0..size).map(|i| &strings[permutations[i]][..]).collect::<Vec<_>>().join(" ");
+    let format = (0..size)
+      .map(|i| format!("{{{}}}", permutations[i]))
+      .collect::<Vec<_>>()
+      .join(" ");
+    let arguments = strings
+      .iter()
+      .map(|item| &item[..])
+      .collect::<Vec<_>>();
+    let expected = (0..size)
+      .map(|i| &strings[permutations[i]][..])
+      .collect::<Vec<_>>()
+      .join(" ");
     assert_eq!(strformat::fmt(format, &arguments), expected);
   }
 }

--- a/Backend/sub_crates/str_util/src/tests/strformat.rs
+++ b/Backend/sub_crates/str_util/src/tests/strformat.rs
@@ -1,6 +1,16 @@
 extern crate proptest;
-use crate::strformat;
 use self::proptest::prelude::*;
+use crate::strformat;
+
+proptest! {
+  #[test]
+  fn test_arguments(size in 0usize..33usize, permutations in prop::array::uniform32(0usize..32usize), strings in prop::array::uniform32("\\PC*")) {
+    let format = (0..size).map(|i| format!("{{{}}}", permutations[i])).collect::<Vec<_>>().join(" ");
+    let arguments = strings.iter().map(|item| &item[..]).collect::<Vec<_>>();
+    let expected = (0..size).map(|i| &strings[permutations[i]][..]).collect::<Vec<_>>().join(" ");
+    assert_eq!(strformat::fmt(format, &arguments), expected);
+  }
+}
 
 #[test]
 fn fmt() {


### PR DESCRIPTION
This adds a simple random test which tests if the function `strformat::fmt()` correctly emplaces strings into a format string. See the comment of the test for more information.