### PR TITLE
Validate password characters

### DIFF
--- a/Backend/src/modules/account/dto/failure.rs
+++ b/Backend/src/modules/account/dto/failure.rs
@@ -12,6 +12,7 @@ pub enum Failure {
     InvalidNickname,
     PwnedPassword(u64),
     PasswordTooShort,
+    InvalidPasswordCharacters,
     MailIsInUse,
     NicknameIsInUse,
     InvalidUrl,
@@ -36,6 +37,7 @@ impl Responder<'static> for Failure {
                 Status::new(523, "PwnedPassword")
             },
             Failure::PasswordTooShort => Status::new(524, "PasswordTooShort"),
+            Failure::InvalidPasswordCharacters => Status::new(400, "InvalidPasswordCharacters"),
             Failure::MailIsInUse => Status::new(525, "MailIsInUse"),
             Failure::NicknameIsInUse => Status::new(526, "NicknameIsInUse"),
             Failure::InvalidUrl => Status::new(527, "InvalidUrl"),

--- a/Backend/src/modules/account/dto/failure.rs
+++ b/Backend/src/modules/account/dto/failure.rs
@@ -37,7 +37,7 @@ impl Responder<'static> for Failure {
                 Status::new(523, "PwnedPassword")
             },
             Failure::PasswordTooShort => Status::new(524, "PasswordTooShort"),
-            Failure::InvalidPasswordCharacters => Status::new(400, "InvalidPasswordCharacters"),
+            Failure::InvalidPasswordCharacters => Status::new(422, "InvalidPasswordCharacters"),
             Failure::MailIsInUse => Status::new(525, "MailIsInUse"),
             Failure::NicknameIsInUse => Status::new(526, "NicknameIsInUse"),
             Failure::InvalidUrl => Status::new(527, "InvalidUrl"),

--- a/Backend/src/modules/account/tools/create.rs
+++ b/Backend/src/modules/account/tools/create.rs
@@ -29,6 +29,7 @@ impl Create for Account {
         }
 
         match valid_password(password) {
+            Err(PasswordFailure::InvalidCharacters) => return Err(Failure::InvalidPasswordCharacters),
             Err(PasswordFailure::TooFewCharacters) => return Err(Failure::PasswordTooShort),
             Err(PasswordFailure::Pwned(num_pwned)) => return Err(Failure::PwnedPassword(num_pwned)),
             Ok(_) => (),

--- a/Backend/src/modules/account/tools/update.rs
+++ b/Backend/src/modules/account/tools/update.rs
@@ -56,6 +56,7 @@ impl Update for Account {
 
     fn change_password(&self, new_password: &str, member_id: u32) -> Result<APIToken, Failure> {
         match valid_password(new_password) {
+            Err(PasswordFailure::InvalidCharacters) => return Err(Failure::InvalidPasswordCharacters),
             Err(PasswordFailure::TooFewCharacters) => return Err(Failure::PasswordTooShort),
             Err(PasswordFailure::Pwned(num_pwned)) => return Err(Failure::PwnedPassword(num_pwned)),
             Ok(_) => (),

--- a/Backend/sub_crates/validator/Cargo.toml
+++ b/Backend/sub_crates/validator/Cargo.toml
@@ -9,4 +9,5 @@ regex = "*"
 lazy_static = "*"
 
 [dev-dependencies]
+proptest = "0.9.6"
 dotenv = "*"

--- a/Backend/sub_crates/validator/proptest-regressions/tests/password.txt
+++ b/Backend/sub_crates/validator/proptest-regressions/tests/password.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc c3b98dff6674ece1c38d4b2ce45bf131673a95f1381b4ccc4895b34ceebe803c # shrinks to pass = "০𐝀 🞀"
+cc 610bfdc5cd06276d4dedcac3ea4a12792efa50b2f59e74d0426dcd1c47069451 # shrinks to pass = "𞠀ઽ𑈀a"

--- a/Backend/sub_crates/validator/proptest-regressions/tests/password.txt
+++ b/Backend/sub_crates/validator/proptest-regressions/tests/password.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc c3b98dff6674ece1c38d4b2ce45bf131673a95f1381b4ccc4895b34ceebe803c # shrinks to pass = "০𐝀 🞀"

--- a/Backend/sub_crates/validator/src/domain_value/password_failure.rs
+++ b/Backend/sub_crates/validator/src/domain_value/password_failure.rs
@@ -1,4 +1,5 @@
 pub enum PasswordFailure {
   TooFewCharacters,
+  InvalidCharacters,
   Pwned(u64),
 }

--- a/Backend/sub_crates/validator/src/tests/password.rs
+++ b/Backend/sub_crates/validator/src/tests/password.rs
@@ -1,9 +1,11 @@
 #[cfg(test)]
 mod tests {
+  extern crate proptest;
   extern crate dotenv;
-  use crate::tools::valid_password;
   use self::dotenv::dotenv;
-
+  use self::proptest::prelude::*;
+  use crate::domain_value::PasswordFailure;
+  use crate::tools::valid_password;
   #[test]
   fn password_too_short() {
     dotenv().ok();
@@ -22,6 +24,22 @@ mod tests {
   fn password_is_secure_enough() {
     dotenv().ok();
     let pass = "Password123456Password123456Password123456";
-    assert!(valid_password(pass).is_ok());
+    assert!(valid_password(&pass).is_ok());
+  }
+
+  proptest! {
+    #[test]
+    fn never_crashes(pass in "\\PC*") {
+      valid_password(&pass);
+    }
+
+    #[test]
+    fn reject_arbitrary_too_short_passwords(pass in "\\PC{0,11}") {
+      let validated = valid_password(&pass);
+      assert!(match validated {
+        Err(PasswordFailure::TooFewCharacters) => true,
+        _ => false
+      });
+    }
   }
 }

--- a/Backend/sub_crates/validator/src/tests/password.rs
+++ b/Backend/sub_crates/validator/src/tests/password.rs
@@ -4,7 +4,6 @@ mod tests {
   extern crate dotenv;
   use self::dotenv::dotenv;
   use self::proptest::prelude::*;
-  use crate::domain_value::PasswordFailure;
   use crate::tools::valid_password;
   #[test]
   fn password_too_short() {
@@ -36,7 +35,7 @@ mod tests {
     #[test]
     fn reject_arbitrary_too_short_passwords(pass in "\\PC{0,11}") {
       let validated = valid_password(&pass);
-      assert!(valid_password(pass).is_err());
+      assert!(valid_password(&pass).is_err());
     }
   }
 }

--- a/Backend/sub_crates/validator/src/tests/password.rs
+++ b/Backend/sub_crates/validator/src/tests/password.rs
@@ -36,10 +36,7 @@ mod tests {
     #[test]
     fn reject_arbitrary_too_short_passwords(pass in "\\PC{0,11}") {
       let validated = valid_password(&pass);
-      assert!(match validated {
-        Err(PasswordFailure::TooFewCharacters) => true,
-        _ => false
-      });
+      assert!(valid_password(pass).is_err());
     }
   }
 }

--- a/Backend/sub_crates/validator/src/tools/password.rs
+++ b/Backend/sub_crates/validator/src/tools/password.rs
@@ -10,11 +10,11 @@ pub fn valid_password(input: &str) -> Result<(), PasswordFailure>
       .build().unwrap();
   }
 
-  if !input.is_ascii() {
+  if !input.chars().all(char::is_alphanumeric) {
     return Err(PasswordFailure::InvalidCharacters);
   }
 
-  if input.len() < 12 {
+  if input.chars().count() < 12 {
     return Err(PasswordFailure::TooFewCharacters);
   }
 

--- a/Backend/sub_crates/validator/src/tools/password.rs
+++ b/Backend/sub_crates/validator/src/tools/password.rs
@@ -10,6 +10,10 @@ pub fn valid_password(input: &str) -> Result<(), PasswordFailure>
       .build().unwrap();
   }
 
+  if !input.is_ascii() {
+    return Err(PasswordFailure::InvalidCharacters);
+  }
+
   if input.len() < 12 {
     return Err(PasswordFailure::TooFewCharacters);
   }


### PR DESCRIPTION
- Commit 80849f6 is my contribution to phase1 of the project. It adds property tests for password validations, which **failed** for non-ascii characters
- I tried to add validation to make sure passwords only include ascii characters