### PR TITLE
Add integration tests for account creation

### DIFF
--- a/Backend/proptest-regressions/modules/account/tests/create_rt.txt
+++ b/Backend/proptest-regressions/modules/account/tests/create_rt.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 890a746ed5cdf24dee6b486359f8b81db34e70d2289187f8339398c1d07fe231 # shrinks to nickname = "A", password = "🂠꜀𖭽 ", mail_prefix = ""
+cc f360da711667485574792904825bcb41e7dd05ccdd20c86a5047713138628957 # shrinks to nickname = "a", password = "𐺰\u{abc}A Ὗ", mail_prefix = ""

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -7,7 +7,7 @@ use mysql_connection::tools::Exists;
 #[test]
 fn create_account_nick_valid_email_valid_password_valid() {
     // Given
-    let rocket = rocket::ignite();
+    let rocket = rocket::ignite().mount("/", routes![create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickName".to_string(),
@@ -16,15 +16,15 @@ fn create_account_nick_valid_email_valid_password_valid() {
             password: "someExtremelySecurePassword".to_string(),
         },
     };
-    let db_client = Account::default().db_main;
-    assert!(!dbClient.exists(&post_obj.credentials.mail));
+    let account = Account::default();
+    assert!(!account.db_main.exists(&post_obj.credentials.mail));
 
     // When
     let req = http_client.post("/create").header(ContentType::JSON).body(post_obj);
     let response = req.dispatch();
 
     // Then
-    assert!(dbClient.exists(&post_obj.credentials.mail));
+    assert!(account.db_main.exists(&post_obj.credentials.mail));
     assert_eq!(response.status(), Status::Ok);
 
     // Clean up

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -4,6 +4,8 @@ use crate::modules::account::dto::{CreateMember, Credentials};
 use crate::modules::account::Account;
 use crate::modules::account::transfer::create::create;
 use mysql_connection::tools::{Exists, Execute};
+use serde::Serialize;
+use serde_json::value::Serializer;
 
 #[test]
 fn create_account_nick_valid_email_valid_password_valid() {
@@ -17,11 +19,12 @@ fn create_account_nick_valid_email_valid_password_valid() {
             password: "someExtremelySecurePassword".to_string(),
         },
     };
+    let json_body = post_obj.serialize(Serializer).unwrap();
     let account = Account::default();
     assert!(!account.db_main.exists("SELECT * FROM account_member WHERE mail='someEmail@someDomain.test'"));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(post_obj);
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str().unwrap());
     let response = req.dispatch();
 
     // Then

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -5,10 +5,10 @@ use crate::modules::account::Account;
 use mysql_connection::tools::Exists;
 
 #[test]
-fn create_account_nick_valid_() {
+fn create_account_nick_valid_email_valid_password_valid() {
     // Given
     let rocket = rocket::ignite();
-    let client = Client::new(rocket).expect("valid rocket instance");
+    let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickName".to_string(),
         credentials: Credentials {
@@ -16,15 +16,15 @@ fn create_account_nick_valid_() {
             password: "someExtremelySecurePassword".to_string(),
         },
     };
-    let dbClient = Account::default().db_main;
-    assert!(!dbClient.exists("someEmail@someDomain.test"));
+    let db_client = Account::default().db_main;
+    assert!(!dbClient.exists(&post_obj.credentials.mail));
 
     // When
-    let req = client.post("/create").header(ContentType::JSON).body(post_obj);
+    let req = http_client.post("/create").header(ContentType::JSON).body(post_obj);
     let response = req.dispatch();
 
     // Then
-    assert!(dbClient.exists(email));
+    assert!(dbClient.exists(&post_obj.credentials.mail));
     assert_eq!(response.status(), Status::Ok);
 
     // Clean up

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -3,33 +3,527 @@ use rocket::http::{ContentType, Status};
 use crate::modules::account::dto::{CreateMember, Credentials};
 use crate::modules::account::Account;
 use mysql_connection::tools::{Exists, Execute};
-use serde::Serialize;
-use serde_json::value::Serializer;
 
 #[test]
 fn create_account_nick_valid_email_valid_password_valid() {
     // Given
-    let rocket = rocket::ignite().mount("/", routes![crate::modules::account::transfer::create::create]);
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    // An http client is created, which will be used to send http requests to the account creation endpoint
     let http_client = Client::new(rocket).expect("valid rocket instance");
+    // An object that contains the input parameters is defined
     let post_obj = CreateMember {
-        nickname: "someNickName".to_string(),
+        nickname: "someNickname".to_string(),
         credentials: Credentials {
             mail: "someEmail@someDomain.test".to_string(),
             password: "someExtremelySecurePassword".to_string(),
         },
     };
-    let json_body = post_obj.serialize(Serializer).unwrap();
+    // Serialize the object to the json format
+    let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists("SELECT * FROM account_member WHERE mail='someEmail@someDomain.test'"));
+    // Verify that no account with this email is known
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str().unwrap());
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    // Http request is send to the endpoint, response is received
     let response = req.dispatch();
 
     // Then
-    assert!(account.db_main.exists("SELECT * FROM account_member WHERE mail='someEmail@someDomain.test'"));
+    // Verify the status code of the response
     assert_eq!(response.status(), Status::Ok);
+    // Verify that the user has been created in the database
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute("DELETE FROM account_member WHERE mail='someEmail@someDomain.test'");
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
+
+#[test]
+fn create_account_nick_used_email_valid_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let post_obj_used= CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someOtherEmail@someDomain.test".to_string(),
+            password: "someOtherExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let response_used = req_used.dispatch();
+
+
+    // Then
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response_used.status(), Status::new(526, "NicknameIsInUse"));
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_valid_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_used_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let post_obj_used = CreateMember {
+        nickname: "someOtherNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let response_used = req_used.dispatch();
+
+
+    // Then
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_malformed_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up (just in case)
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_valid_password_too_short() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "tooShort".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(524, "PasswordTooShort"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up (just in case)
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_valid_password_pwned() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "correcthorsebatterystaple".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(523, "PwnedPassword"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up (just in case)
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_malformed_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_valid_password_too_short() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "tooShort".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_valid_password_pwned() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "correcthorsebatterystaple".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_malformed_password_too_short() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "tooShort".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_valid_email_malformed_password_pwned() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "correcthorsebatterystaple".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_malformed_password_too_short() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "tooShort".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_malformed_password_pwned() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someMalformedEmail".to_string(),
+            password: "correcthorsebatterystaple".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+
+    // Then
+    assert_eq!(response.status(), Status::new(521, "InvalidMail"));
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+
+#[test]
+fn create_account_nick_used_email_used_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let post_obj_used = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let response_used = req_used.dispatch();
+
+
+    // Then
+    assert_eq!(response.status(), Status::Ok);
+    assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+
+#[test]
+fn create_account_nick_malformed_email_used_password_valid() {
+    // Given
+    let account = Account::default();
+    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let http_client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body = serde_json::to_string(&post_obj).unwrap();
+    let post_obj_used = CreateMember {
+        nickname: "some malformed nickname".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
+    let account = Account::default();
+    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let response = req.dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
+    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let response_used = req_used.dispatch();
+
+    // Then
+    assert_eq!(response_used.status(), Status::new(522, "InvalidNickname"));
+
+    // Clean up
+    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+}
+

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -17,7 +17,7 @@ fn create_account_nick_valid_() {
         },
     };
     let dbClient = Account::default().db_main;
-    assert!(!dbClient.exists(email));
+    assert!(!dbClient.exists("someEmail@someDomain.test"));
 
     // When
     let req = client.post("/create").header(ContentType::JSON).body(post_obj);

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -1,0 +1,32 @@
+use rocket::local::Client;
+use rocket::http::ContentType;
+use crate::modules::account::dto::{CreateMember, Credentials};
+use crate::modules::account::Account;
+use mysql_connection::tools::Exists;
+
+#[test]
+fn create_account_nick_valid_() {
+    // Given
+    let rocket = rocket::ignite();
+    let client = Client::new(rocket).expect("valid rocket instance");
+    let post_obj = CreateMember {
+        nickname: "someNickName".to_string(),
+        credentials: Credentials {
+            mail: "someEmail@someDomain.test".to_string(),
+            password: "someExtremelySecurePassword".to_string(),
+        },
+    };
+    let dbClient = Account::default().db_main;
+    assert!(!dbClient.exists(email));
+
+    // When
+    let req = client.post("/create").header(ContentType::JSON).body(post_obj);
+    let response = req.dispatch();
+
+    // Then
+    assert!(dbClient.exists(email));
+    assert_eq!(response.status(), Status::Ok);
+
+    // Clean up
+    account.db_main.execute("DELETE FROM account_member WHERE mail='someEmail@someDomain.test'");
+}

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -1,8 +1,9 @@
 use rocket::local::Client;
-use rocket::http::ContentType;
+use rocket::http::{ContentType, Status};
 use crate::modules::account::dto::{CreateMember, Credentials};
 use crate::modules::account::Account;
-use mysql_connection::tools::Exists;
+use crate::modules::account::transfer::create::create;
+use mysql_connection::tools::{Exists, Execute};
 
 #[test]
 fn create_account_nick_valid_email_valid_password_valid() {

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -8,8 +8,10 @@ use mysql_connection::tools::{Exists, Execute};
 fn create_account_nick_valid_email_valid_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
-    // An http client is created, which will be used to send http requests to the account creation endpoint
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
+    // An http client is created, which will
+    // be used to send http requests to the account creation endpoint
     let http_client = Client::new(rocket).expect("valid rocket instance");
     // An object that contains the input parameters is defined
     let post_obj = CreateMember {
@@ -23,10 +25,12 @@ fn create_account_nick_valid_email_valid_password_valid() {
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
     // Verify that no account with this email is known
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     // Http request is send to the endpoint, response is received
     let response = req.dispatch();
 
@@ -34,17 +38,20 @@ fn create_account_nick_valid_email_valid_password_valid() {
     // Verify the status code of the response
     assert_eq!(response.status(), Status::Ok);
     // Verify that the user has been created in the database
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_used_email_valid_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -63,32 +70,41 @@ fn create_account_nick_used_email_valid_password_valid() {
     };
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
     // Create an account for this nickname
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let req_used = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
     // Then
     assert_eq!(response_used.status(), Status::new(526, "NicknameIsInUse"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_valid_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -99,25 +115,30 @@ fn create_account_nick_malformed_email_valid_password_valid() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_used_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -136,29 +157,35 @@ fn create_account_nick_valid_email_used_password_valid() {
     };
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
     // Create an account for this email
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let req_used = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
     // Then
     assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_malformed_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -169,25 +196,30 @@ fn create_account_nick_valid_email_malformed_password_valid() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up (just in case)
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_valid_password_too_short() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -198,25 +230,30 @@ fn create_account_nick_valid_email_valid_password_too_short() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(524, "PasswordTooShort"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up (just in case)
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_valid_password_pwned() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -227,25 +264,30 @@ fn create_account_nick_valid_email_valid_password_pwned() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(523, "PwnedPassword"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up (just in case)
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_malformed_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -256,25 +298,30 @@ fn create_account_nick_malformed_email_malformed_password_valid() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_valid_password_too_short() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -285,25 +332,30 @@ fn create_account_nick_malformed_email_valid_password_too_short() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_valid_password_pwned() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -314,25 +366,30 @@ fn create_account_nick_malformed_email_valid_password_pwned() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(522, "InvalidNickname"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_malformed_password_too_short() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -343,25 +400,30 @@ fn create_account_nick_valid_email_malformed_password_too_short() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_valid_email_malformed_password_pwned() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -372,25 +434,30 @@ fn create_account_nick_valid_email_malformed_password_pwned() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_malformed_password_too_short() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -401,25 +468,30 @@ fn create_account_nick_malformed_email_malformed_password_too_short() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_malformed_password_pwned() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "some malformed nickname".to_string(),
@@ -430,18 +502,22 @@ fn create_account_nick_malformed_email_malformed_password_pwned() {
     };
     let json_body = serde_json::to_string(&post_obj).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
 
     // Then
     assert_eq!(response.status(), Status::new(521, "InvalidMail"));
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 
@@ -449,7 +525,8 @@ fn create_account_nick_malformed_email_malformed_password_pwned() {
 fn create_account_nick_used_email_used_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -468,29 +545,35 @@ fn create_account_nick_used_email_used_password_valid() {
     };
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
     // Create an account for this user
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let req_used = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
     // Then
     assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+        "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 
 #[test]
 fn create_account_nick_malformed_email_used_password_valid() {
     // Given
     let account = Account::default();
-    let rocket = rocket::ignite().manage(account).mount("/", routes![crate::modules::account::transfer::create::create]);
+    let rocket = rocket::ignite().manage(account)
+        .mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickname".to_string(),
@@ -509,21 +592,26 @@ fn create_account_nick_malformed_email_used_password_valid() {
     };
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
-    assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(!account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
     // Create an account for this email
-    let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
+    let req = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+    assert!(account.db_main.exists(&format!(
+        "SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // When
-    let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
+    let req_used = http_client.post("/create")
+        .header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
     // Then
     assert_eq!(response_used.status(), Status::new(522, "InvalidNickname"));
 
     // Clean up
-    account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
+    account.db_main.execute(&format!(
+    "DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
 }
 

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -65,18 +65,18 @@ fn create_account_nick_used_email_valid_password_valid() {
     let account = Account::default();
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
-
-    // When
+    // Create an account for this nickname
     let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
     let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
-
     // Then
-    assert_eq!(response.status(), Status::Ok);
     assert_eq!(response_used.status(), Status::new(526, "NicknameIsInUse"));
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj_used.credentials.mail)));
 
     // Clean up
@@ -137,18 +137,18 @@ fn create_account_nick_valid_email_used_password_valid() {
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
-
-    // When
+    // Create an account for this email
     let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
     let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
-
     // Then
-    assert_eq!(response.status(), Status::Ok);
     assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
     account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
@@ -469,18 +469,18 @@ fn create_account_nick_used_email_used_password_valid() {
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
-
-    // When
+    // Create an account for this user
     let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
+    assert_eq!(response.status(), Status::Ok);
+    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
+
+    // When
     let req_used = http_client.post("/create").header(ContentType::JSON).body(json_body_used.as_str());
     let response_used = req_used.dispatch();
 
-
     // Then
-    assert_eq!(response.status(), Status::Ok);
     assert_eq!(response_used.status(), Status::new(525, "MailIsInUse"));
-    assert!(account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
 
     // Clean up
     account.db_main.execute(&format!("DELETE FROM account_member WHERE mail='{}'", post_obj.credentials.mail));
@@ -510,7 +510,7 @@ fn create_account_nick_malformed_email_used_password_valid() {
     let json_body_used = serde_json::to_string(&post_obj_used).unwrap();
     let account = Account::default();
     assert!(!account.db_main.exists(&format!("SELECT * FROM account_member WHERE mail='{}'", post_obj.credentials.mail)));
-
+    // Create an account for this email
     let req = http_client.post("/create").header(ContentType::JSON).body(json_body.as_str());
     let response = req.dispatch();
     assert_eq!(response.status(), Status::Ok);

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -17,14 +17,14 @@ fn create_account_nick_valid_email_valid_password_valid() {
         },
     };
     let account = Account::default();
-    assert!(!account.db_main.exists(&post_obj.credentials.mail));
+    assert!(!account.db_main.exists("SELECT * FROM account_member WHERE mail='someEmail@someDomain.test'"));
 
     // When
     let req = http_client.post("/create").header(ContentType::JSON).body(post_obj);
     let response = req.dispatch();
 
     // Then
-    assert!(account.db_main.exists(&post_obj.credentials.mail));
+    assert!(account.db_main.exists("SELECT * FROM account_member WHERE mail='someEmail@someDomain.test'"));
     assert_eq!(response.status(), Status::Ok);
 
     // Clean up

--- a/Backend/src/modules/account/tests/create_transfer.rs
+++ b/Backend/src/modules/account/tests/create_transfer.rs
@@ -2,7 +2,6 @@ use rocket::local::Client;
 use rocket::http::{ContentType, Status};
 use crate::modules::account::dto::{CreateMember, Credentials};
 use crate::modules::account::Account;
-use crate::modules::account::transfer::create::create;
 use mysql_connection::tools::{Exists, Execute};
 use serde::Serialize;
 use serde_json::value::Serializer;
@@ -10,7 +9,7 @@ use serde_json::value::Serializer;
 #[test]
 fn create_account_nick_valid_email_valid_password_valid() {
     // Given
-    let rocket = rocket::ignite().mount("/", routes![create]);
+    let rocket = rocket::ignite().mount("/", routes![crate::modules::account::transfer::create::create]);
     let http_client = Client::new(rocket).expect("valid rocket instance");
     let post_obj = CreateMember {
         nickname: "someNickName".to_string(),

--- a/Backend/src/modules/account/tests/mod.rs
+++ b/Backend/src/modules/account/tests/mod.rs
@@ -1,5 +1,6 @@
 mod create;
 mod create_rt;
+mod create_transfer;
 mod delete;
 mod forgot;
 mod get;


### PR DESCRIPTION
My submission for phase 2 of the project. All tests pass 😊 
Big thanks to Tom for the help 🙏

These tests are integration tests that check the http endpoint for creating an account. It tests the endpoint for a completely valid account creation request, as well as possible invalid requests. 

I had to combine multiple invalid inputs to reach the 16 tests. I am not convinced that this provides any value and I think covering the base choice criterion would be sufficient. For this, 7 tests are required and I would be open to deleting the other 9 tests, if requested :+1: