### PR TITLE
rewrite language dictionary and add more tests

### DIFF
--- a/Backend/sub_crates/language/Cargo.toml
+++ b/Backend/sub_crates/language/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["Tom Dymel <tom@dymel.dev>"]
 
 [dependencies]
 dotenv = "*"
+strum = "*"
+strum_macros = "*"

--- a/Backend/sub_crates/language/src/domain_value/language.rs
+++ b/Backend/sub_crates/language/src/domain_value/language.rs
@@ -1,5 +1,6 @@
 #[repr(u8)]
 #[derive(PartialEq)]
+#[derive(EnumCount, EnumIter)]
 pub enum Language {
     English = 0,
     German = 1,

--- a/Backend/sub_crates/language/src/domain_value/language.rs
+++ b/Backend/sub_crates/language/src/domain_value/language.rs
@@ -1,6 +1,5 @@
 #[repr(u8)]
-#[derive(PartialEq)]
-#[derive(EnumCount, EnumIter)]
+#[derive(EnumCount, EnumIter, PartialEq)]
 pub enum Language {
     English = 0,
     German = 1,

--- a/Backend/sub_crates/language/src/lib.rs
+++ b/Backend/sub_crates/language/src/lib.rs
@@ -1,3 +1,7 @@
+extern crate strum;
+#[macro_use]
+extern crate strum_macros;
+
 pub mod domain_value;
 pub mod material;
 mod tests;

--- a/Backend/sub_crates/language/src/material/dictionary.rs
+++ b/Backend/sub_crates/language/src/material/dictionary.rs
@@ -3,7 +3,7 @@ use std::sync::RwLock;
 
 #[derive(Debug)]
 pub struct Dictionary {
-    pub table: RwLock<HashMap<String, Vec<String>>>,
+    pub table: RwLock<HashMap<String, Vec<Option<String>>>>,
 }
 
 impl Default for Dictionary {

--- a/Backend/sub_crates/language/src/tests/get.rs
+++ b/Backend/sub_crates/language/src/tests/get.rs
@@ -34,4 +34,157 @@ mod tests {
         dictionary.register("Test", Language::Japanese, "test");
         assert_eq!(dictionary.get("Test", Language::Japanese), "test")
     }
+    #[test]
+    #[should_panic(expected = "Value is empty for key 'Test' and language 0")]
+    fn has_empty_translation() {
+        let dictionary = Dictionary::default();
+        dictionary.register("Test", Language::English, "");
+        dictionary.get("Test", Language::English);
+    }
+
+    /*
+    Tests derived by input space partitioning with the following characteristics:
+    empty/nonempty key
+    key pure ASCII or with at least one non-ASCII character
+    0, 1, >1 translations
+    translation for requested is available or not
+    translation is valid or not (empty string or nonempty string)
+     */
+    #[test]
+    #[should_panic(expected = "Key '' is not registered")]
+    fn keyEmpty_0Translations() {
+        let dictionary = Dictionary::default();
+        dictionary.get("", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'äöüß' is not registered")]
+    fn keyNonEmpty_nonAscii_0Translations() {
+        let dictionary = Dictionary::default();
+        dictionary.get("äöüß", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'Test' is not registered")]
+    fn keyNonEmpty_ascii_0Translations() {
+        let dictionary = Dictionary::default();
+        dictionary.get("Test", Language::English);
+    }
+
+    #[test]
+    fn keyEmpty_1Translations_available_valid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::English, "test");
+        assert_eq!(dictionary.get("", Language::English), "test");
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'Test' is not registered for language 0")]
+    fn keyNonEmpty_ascii_1Translations_NotAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("Test", Language::Japanese, "");
+        dictionary.get("Test", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value is empty for key 'Test' and language 0")]
+    fn keyNonEmpty_ascii_2Translations_available_invalid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("Test", Language::Japanese, "test_jp");
+        dictionary.register("Test", Language::English, "");
+        dictionary.get("Test", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value is empty for key '' and language 0")]
+    fn keyEmpty_2Translations_available_invalid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::Japanese, "test_jp");
+        dictionary.register("", Language::English, "");
+        dictionary.get("", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value is empty for key 'äöü' and language 0")]
+    fn keyNonEmpty_nonAscii_2Translations_available_invalid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("äöü", Language::Japanese, "test_jp");
+        dictionary.register("äöü", Language::English, "");
+        dictionary.get("äöü", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'Test' is not registered for language 0")]
+    fn keyNonEmpty_ascii_2Translations_notAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("Test", Language::Japanese, "test_jp");
+        dictionary.register("Test", Language::German, "test_ge");
+        dictionary.get("Test", Language::English);
+    }
+
+    #[test]
+    fn keyNonEmpty_ascii_2Translations_available_valid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("Test", Language::Japanese, "test_jp");
+        dictionary.register("Test", Language::English, "test_en");
+        assert_eq!(dictionary.get("Test", Language::English), "test_en");
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'äöü' is not registered for language 0")]
+    fn keyNonEmpty_nonAscii_1Translations_notAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("äöü", Language::Japanese, "test_jp");
+        dictionary.get("äöü", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key 'äöü' is not registered for language 0")]
+    fn keyNonEmpty_nonAscii_2Translations_notAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("äöü", Language::Japanese, "test_jp");
+        dictionary.register("äöü", Language::German, "test_ge");
+        dictionary.get("äöü", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key '' is not registered for language 0")]
+    fn keyEmpty_1Translations_notAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::Japanese, "test_jp");
+        dictionary.get("", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Key '' is not registered for language 0")]
+    fn keyEmpty_2Translations_notAvailable() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::Japanese, "test_jp");
+        dictionary.register("", Language::German, "test_ge");
+        dictionary.get("", Language::English);
+    }
+
+    #[test]
+    #[should_panic(expected = "Value is empty for key 'äöü' and language 0")]
+    fn keyNonEmpty_nonAscii_1Translations_available_invalid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("äöü", Language::English, "");
+        dictionary.get("äöü", Language::English);
+    }
+
+    #[test]
+    fn keyEmpty_2Translations_available_valid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::Japanese, "test_jp");
+        dictionary.register("", Language::English, "test_en");
+        dictionary.get("", Language::English);
+    }
+
+    #[test]
+    fn keyEmpty_ascii_2Translations_available_valid() {
+        let dictionary = Dictionary::default();
+        dictionary.register("", Language::Japanese, "test_jp");
+        dictionary.register("", Language::English, "test_en");
+        assert_eq!(dictionary.get("", Language::English), "test_en");
+    }
 }

--- a/Backend/sub_crates/language/src/tools/get.rs
+++ b/Backend/sub_crates/language/src/tools/get.rs
@@ -10,17 +10,19 @@ impl Get for Dictionary {
         let lang_table = self.table.read().unwrap();
         let lang_index = language as usize;
         match lang_table.get(key) {
-            Some(translations) => match translations.get(lang_index) {
-                Some(value) => {
-                    if value.is_empty() {
-                        panic!("Value is empty for key {} and language {}", key, lang_index)
-                    } else {
-                        value.to_string()
-                    }
-                },
-                None => panic!("Key {} is not registered for language {}", key, lang_index),
+            Some(translations_vec) => {
+                match &translations_vec.get(lang_index).unwrap_or(&None) {
+                    Some(value) => {
+                        if value.is_empty() {
+                            panic!("Value is empty for key '{}' and language {}", key, lang_index)
+                        } else {
+                            value.to_string()
+                        }
+                    },
+                    None => panic!("Key '{}' is not registered for language {}", key, lang_index),
+                }
             },
-            None => panic!("Key {} is not registered", key),
+            None => panic!("Key '{}' is not registered", key),
         }
     }
 }

--- a/Backend/sub_crates/language/src/tools/register.rs
+++ b/Backend/sub_crates/language/src/tools/register.rs
@@ -20,34 +20,18 @@ impl Register for Dictionary {
             value_str = value_str.replace(&format!("{{{env_key}}}", env_key = key), &val);
         }
         let lang_index = language as usize;
-        match lang_table.get_mut(&key_str) {
-            Some(vec) => {
-                let vec_length = vec.len();
-                match vec.get_mut(lang_index) {
-                    Some(content) => {
-                        if content.is_empty() {
-                            *content = value_str;
-                        } else {
-                            panic!("{} is overwritten for the language {} with the content {}!", key, lang_index, value);
-                        }
-                    },
-                    // This means that the vector has not been extended to this language yet
-                    None => {
-                        for _ in vec_length..lang_index {
-                            vec.push(String::new());
-                        }
-                        vec.push(value_str);
-                    },
-                }
+        if !lang_table.contains_key(&key_str) {
+            lang_table.insert(String::from(&key_str), Vec::<Option<String>>::new());
+        }
+        let vec = lang_table.get_mut(&key_str).unwrap();
+        for _ in vec.len()..lang_index + 1 {
+            vec.push(None);
+        }
+        match &vec[lang_index] {
+            Some(_) => {
+                panic!("{} is overwritten for the language {} with the content {}!", key, lang_index, value);
             },
-            None => {
-                let mut container: Vec<String> = Vec::new();
-                for _ in 0..lang_index {
-                    container.push(String::new());
-                }
-                container.push(value_str);
-                lang_table.insert(key_str, container);
-            },
+            None => vec[lang_index] = Some(value_str),
         }
     }
 }

--- a/Backend/sub_crates/language/src/tools/register.rs
+++ b/Backend/sub_crates/language/src/tools/register.rs
@@ -1,5 +1,7 @@
 extern crate dotenv;
 
+use strum::EnumCount;
+
 use crate::domain_value::Language;
 use crate::material::Dictionary;
 
@@ -21,12 +23,9 @@ impl Register for Dictionary {
         }
         let lang_index = language as usize;
         if !lang_table.contains_key(&key_str) {
-            lang_table.insert(String::from(&key_str), Vec::<Option<String>>::new());
+            lang_table.insert(String::from(&key_str), vec![None; Language::count()]);
         }
         let vec = lang_table.get_mut(&key_str).unwrap();
-        for _ in vec.len()..lang_index + 1 {
-            vec.push(None);
-        }
         match &vec[lang_index] {
             Some(_) => {
                 panic!("{} is overwritten for the language {} with the content {}!", key, lang_index, value);


### PR DESCRIPTION
dict impl behavior is unexpected when a key is registered, but has no translation for requested language.
I would expect "Key [...] is not registered for language [...]", instead of "Value is empty for key [...] and language [...]".
Might fix this myself if I find time...