### PR TITLE
Add tests for live data processor and fix bug in spell cast parsing

### DIFF
--- a/Backend/src/modules/live_data_processor/tests/mod.rs
+++ b/Backend/src/modules/live_data_processor/tests/mod.rs
@@ -3,3 +3,4 @@ mod guid;
 mod message;
 mod message_type;
 mod server_process;
+mod try_parse_spell_cast;

--- a/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
+++ b/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
@@ -9,11 +9,13 @@ fn test_correct_shortcut_condition() {
     let container = TestContainer::new(false);
     let (dns, _node) = container.run();
 
+    // setup dependencies
     let armory = Armory::with_dns((dns + "main").as_str());
 
     let mut summons: HashMap<u64, u64> = HashMap::new();
     summons.insert(1, 1);
 
+    // setup helper objects
     let sender_unit = Unit {
         is_player: false,
         unit_id: 0,
@@ -74,11 +76,13 @@ fn test_correct_shortcut_condition() {
         }),
     };
 
+    // define test case helper struct
     struct TestCase {
         non_committed_messages: Vec<Message>,
         is_some: bool,
     };
 
+    // define test cases
     let mut test_cases = vec![
         TestCase {
             non_committed_messages: vec![spell_cast_message.clone()],
@@ -122,10 +126,13 @@ fn test_correct_shortcut_condition() {
         },
     ];
 
+    // execute test cases
     for test_case in test_cases.iter_mut() {
         let first_message = test_case.non_committed_messages.first().expect("there must be at least one non-committed message").clone();
         let non_committed_messages = test_case.non_committed_messages.clone();
+
         let spell_cast = try_parse_spell_cast(&mut test_case.non_committed_messages, &summons, &first_message, &armory, 42);
+
         assert_eq!(
             spell_cast.is_some(),
             test_case.is_some,

--- a/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
+++ b/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
@@ -10,7 +10,7 @@ fn test_correct_shortcut_condition() {
     let (dns, _node) = container.run();
 
     // setup dependencies
-    let armory = Armory::with_dns((dns + "main").as_str());
+    let armory = Armory::with_dns(&dns);
 
     let mut summons: HashMap<u64, u64> = HashMap::new();
     summons.insert(1, 1);

--- a/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
+++ b/Backend/src/modules/live_data_processor/tests/try_parse_spell_cast.rs
@@ -1,0 +1,137 @@
+use crate::modules::armory::Armory;
+use crate::modules::live_data_processor::dto::{DamageDone, HealDone, Message, MessageType, SpellCast, Threat, Unit};
+use crate::modules::live_data_processor::tools::server::{try_parse_spell_cast};
+use crate::tests::TestContainer;
+use std::collections::HashMap;
+
+#[test]
+fn test_correct_shortcut_condition() {
+    let container = TestContainer::new(false);
+    let (dns, _node) = container.run();
+
+    let armory = Armory::with_dns((dns + "main").as_str());
+
+    let mut summons: HashMap<u64, u64> = HashMap::new();
+    summons.insert(1, 1);
+
+    let sender_unit = Unit {
+        is_player: false,
+        unit_id: 0,
+    };
+    let receiver_unit = Unit {
+        is_player: false,
+        unit_id: 1,
+    };
+    let spell_cast_message = Message {
+        api_version: 0,
+        message_length: 0,
+        timestamp: 0,
+        message_type: MessageType::SpellCast(SpellCast {
+            caster: sender_unit.clone(),
+            target: Some(receiver_unit.clone()),
+            spell_id: 42,
+            hit_type: 7,
+        }),
+    };
+    let heal_message = Message {
+        api_version: 0,
+        message_length: 0,
+        timestamp: 0,
+        message_type: MessageType::Heal(HealDone {
+            caster: sender_unit.clone(),
+            target: receiver_unit.clone(),
+            spell_id: 42,
+            total_heal: 420,
+            effective_heal: 42,
+            absorb: 2,
+        }),
+    };
+    let spell_damage_message = Message {
+        api_version: 0,
+        message_length: 0,
+        timestamp: 0,
+        message_type: MessageType::SpellDamage(DamageDone {
+            attacker: sender_unit.clone(),
+            victim: receiver_unit.clone(),
+            spell_id: Some(42),
+            hit_type: None,
+            blocked: 1,
+            school: 2,
+            damage: 10,
+            resisted_or_glanced: 1,
+            absorbed: 1,
+        }),
+    };
+    let threat_message = Message {
+        api_version: 0,
+        message_length: 0,
+        timestamp: 0,
+        message_type: MessageType::Threat(Threat {
+            threater: sender_unit,
+            threatened: receiver_unit,
+            spell_id: Some(42),
+            amount: 42,
+        }),
+    };
+
+    struct TestCase {
+        non_committed_messages: Vec<Message>,
+        is_some: bool,
+    };
+
+    let mut test_cases = vec![
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), spell_damage_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), spell_damage_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), heal_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), spell_damage_message.clone(), heal_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), threat_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), spell_damage_message.clone(), threat_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message.clone(), heal_message.clone(), threat_message.clone()],
+            is_some: false,
+        },
+        TestCase {
+            non_committed_messages: vec![spell_cast_message, spell_damage_message, heal_message, threat_message],
+            is_some: true,
+        },
+    ];
+
+    for test_case in test_cases.iter_mut() {
+        let first_message = test_case.non_committed_messages.first().expect("there must be at least one non-committed message").clone();
+        let non_committed_messages = test_case.non_committed_messages.clone();
+        let spell_cast = try_parse_spell_cast(&mut test_case.non_committed_messages, &summons, &first_message, &armory, 42);
+        assert_eq!(
+            spell_cast.is_some(),
+            test_case.is_some,
+            "resulting spell cast should be {} (testing with non-committed messages: {:?})",
+            test_case.is_some,
+            non_committed_messages
+        );
+    }
+}

--- a/Backend/src/modules/live_data_processor/tools/server/spell_cast.rs
+++ b/Backend/src/modules/live_data_processor/tools/server/spell_cast.rs
@@ -78,7 +78,7 @@ pub fn try_parse_spell_cast(non_committed_messages: &mut Vec<Message>, summons: 
         }
     } else if let Some(spell_cast_message) = spell_cast_message {
         if let MessageType::SpellCast(spell_cast) = &spell_cast_message.message_type {
-            if reached_timeout || (threat_message.is_some() && spell_damage_done_message.is_some() || heal_message.is_some()) {
+            if reached_timeout || (threat_message.is_some() && spell_damage_done_message.is_some() && heal_message.is_some()) {
                 non_committed_messages.remove_item(&spell_cast_message).expect("Should be deleted!");
                 return Some(SpellCast {
                     victim: spell_cast.target.as_ref().map(|target| target.to_unit(armory, server_id, summons).expect("Must be an Unit")), // TODO: Handle this in the future, we may have objects there!


### PR DESCRIPTION
This PR introduces new tests for testing the shortcut condition of `try_parse_spell_cast()` when parsing spell casts in the live data processor. One bug has been discovered and fixed in this PR with the test.

It is assumed that each spell cast may follow one of each damage/heal/threat event during a time window. Either when no more messages within the time window or all three events have arrived, the spell cast is considered complete, is returned and remove from the uncommitted events.

The bug effects the shortcut condition becoming true too early and thus discarding/ignoring following events that are associated with the spell cast.