### PR TITLE
Run CI workflow for PRs

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,5 @@
 name: CI
-on:
-  push:
-    branches:
-      - 'master'
-      - 'dev'
+on: push
 
 jobs:
   frontend:
@@ -112,6 +108,7 @@ jobs:
 
       - name: Uploading coverage data
         uses: codecov/codecov-action@v1
+        if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/dev'
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./lcov.info


### PR DESCRIPTION
Runs the github actions workflow for every branch, but only upload the coverage report for `master` and `dev`

You can verify that the workflow is executed in my forked repository:
https://github.com/m-dobler/LegacyPlayersV3/actions/runs/141907544

Edit: It ran, but failed and I am not sure why 😞 