### PR TITLE
Ignore Vulnerability Bonus trailer logs

### DIFF
--- a/Backend/src/modules/live_data_processor/tools/cbl_parser/wow_vanilla/parse_trailer.rs
+++ b/Backend/src/modules/live_data_processor/tools/cbl_parser/wow_vanilla/parse_trailer.rs
@@ -10,6 +10,13 @@ pub fn parse_trailer(trailer: &str) -> Vec<(Option<u32>, HitType)> {
             result.push((None, HitType::Crushing));
         } else if !ind_trailer.is_empty() {
             let parts = ind_trailer.split(' ').collect::<Vec<&str>>();
+
+            // Some private servers seems to have implemented "Vulnerability Bonus" which was removed on 1.9
+            // It is decided to ignore this vulnerability trailer.
+            if parts[1] == "vulnerability" {
+                continue;
+            }
+
             if let Ok(amount) = u32::from_str_radix(&parts[0], 10) {
                 let hit_type = match parts[1] {
                     "resisted" => HitType::PartialResist,


### PR DESCRIPTION
As discussed with @Geigerkind, we ignore these trailer logs as it is not official 1.12 logs.

fixes #156 